### PR TITLE
Includes copyright and license in sources

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,22 +1,45 @@
 on: [push]
 name: build
 jobs:
-  build:
+  analyze:
+    name: Dusk Analyzer
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          components: clippy
-      - name: build
-        uses: actions-rs/cargo@v1
+          profile: minimal
+      - uses: actions-rs/cargo@v1
         with:
-          command: build
-      - name: test
-        uses: actions-rs/cargo@v1
+          command: install
+          args: --git https://github.com/dusk-network/cargo-dusk-analyzer
+      - uses: actions-rs/cargo@v1
+        with:
+          command: dusk-analyzer
+
+  test_nightly:
+    name: Nightly tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+      - uses: actions-rs/cargo@v1
         with:
           command: test
-      - name: lint
-        uses: actions-rs/clippy-check@v1
+
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          profile: minimal
+      - run: rustup component add rustfmt
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+

--- a/bin/main.rs
+++ b/bin/main.rs
@@ -1,3 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
 use clap::{App, Arg};
 use kadcast::Server;
 use rustc_tools_util::{get_version_info, VersionInfo};

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,3 @@
 max_width = 80
+newline_style = "Unix"
 wrap_comments = true

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -1,3 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
 use std::error::Error;
 use std::io::{Read, Write};
 

--- a/src/encoding/error.rs
+++ b/src/encoding/error.rs
@@ -1,3 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
 use std::error::Error;
 use std::fmt;
 

--- a/src/encoding/header.rs
+++ b/src/encoding/header.rs
@@ -1,3 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
 use std::error::Error;
 use std::io::{Read, Write};
 

--- a/src/encoding/message.rs
+++ b/src/encoding/message.rs
@@ -1,3 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
 use std::{
     error::Error,
     io::{Read, Write},

--- a/src/encoding/payload.rs
+++ b/src/encoding/payload.rs
@@ -1,3 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
 pub(super) mod broadcast;
 pub(super) mod nodes;
 pub(crate) use crate::encoding::payload::broadcast::BroadcastPayload;

--- a/src/encoding/payload/broadcast.rs
+++ b/src/encoding/payload/broadcast.rs
@@ -1,3 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
 use std::error::Error;
 use std::io::{Read, Write};
 

--- a/src/encoding/payload/nodes.rs
+++ b/src/encoding/payload/nodes.rs
@@ -1,3 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
 use std::io::{Read, Write};
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 use std::{convert::TryInto, error::Error};

--- a/src/handling.rs
+++ b/src/handling.rs
@@ -1,3 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
 use std::net::SocketAddr;
 use std::{convert::TryInto, sync::Arc};
 

--- a/src/kbucket.rs
+++ b/src/kbucket.rs
@@ -1,3 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
 use std::collections::HashMap;
 use std::time::Duration;
 

--- a/src/kbucket/bucket.rs
+++ b/src/kbucket/bucket.rs
@@ -1,3 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
 use std::time::Duration;
 
 use crate::K_K;

--- a/src/kbucket/key.rs
+++ b/src/kbucket/key.rs
@@ -1,3 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
 use crate::encoding::Marshallable;
 use crate::K_ID_LEN_BYTES;
 use crate::K_NONCE_LEN;

--- a/src/kbucket/node.rs
+++ b/src/kbucket/node.rs
@@ -1,3 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
 use std::time::{Duration, Instant};
 
 use super::key::BinaryID;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
 use std::{convert::TryInto, net::SocketAddr, sync::Arc, time::Duration};
 
 use encoding::{message::Message, payload::BroadcastPayload};

--- a/src/mantainer.rs
+++ b/src/mantainer.rs
@@ -1,3 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
 use std::net::ToSocketAddrs;
 use std::sync::Arc;
 use std::time::Duration;

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -1,3 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
 use crate::kbucket::{BinaryID, BinaryKey};
 use blake2::{Blake2s, Digest};
 use std::convert::TryInto;

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1,3 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
 use std::{error::Error, net::SocketAddr};
 
 use tokio::{

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,3 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
 #[cfg(test)]
 mod tests {
 


### PR DESCRIPTION
- CI now includes `cargo-dusk-analyzer` check
- Change `rustfmt.toml` to force `newline_style`

Resolves: #43