### PR TITLE
Add `PlainEncoder` as dummy plain encoder

### DIFF
--- a/src/mantainer.rs
+++ b/src/mantainer.rs
@@ -22,7 +22,7 @@ pub(crate) struct TableMantainer {}
 impl TableMantainer {
     pub async fn start(
         bootstrapping_nodes: Vec<String>,
-        ktable: &Arc<RwLock<Tree<PeerInfo>>>,
+        ktable: Arc<RwLock<Tree<PeerInfo>>>,
         outbound_sender: Sender<MessageBeanOut>,
     ) {
         let find_nodes = Message::FindNodes(

--- a/src/transport/encoding.rs
+++ b/src/transport/encoding.rs
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+mod plain_encoder;
+pub(crate) use plain_encoder::PlainEncoder;
+
+use crate::encoding::payload::BroadcastPayload;
+pub(crate) trait Encoder {
+    fn encode<'msg>(&self, msg: &'msg [u8]) -> Vec<&'msg [u8]>;
+
+    fn decode(&self, chunk: BroadcastPayload) -> Option<BroadcastPayload>;
+}

--- a/src/transport/encoding/plain_encoder.rs
+++ b/src/transport/encoding/plain_encoder.rs
@@ -1,0 +1,21 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use crate::encoding::payload::BroadcastPayload;
+
+use super::Encoder;
+
+pub(crate) struct PlainEncoder {}
+
+impl Encoder for PlainEncoder {
+    fn encode<'msg>(&self, msg: &'msg [u8]) -> Vec<&'msg [u8]> {
+        vec![msg]
+    }
+
+    fn decode(&self, chunk: BroadcastPayload) -> Option<BroadcastPayload> {
+        Some(chunk)
+    }
+}


### PR DESCRIPTION
- Add `Encoder` trait as prerequisite to introduce RaptorQ
- Adapt codebase to use `Encoder`

Resolves: #52