### PR TITLE
Added auto-propagate flag for broadcast messages

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 This document explains the architecture of the library components. The low-level networking and threading infrastructure makes use of async [Tokio runtime](https://docs.rs/tokio). In the future, the code will be made modular so to allow the use of [different runtimes](https://rust-lang.github.io/async-book/08_ecosystem/00_chapter.html).
 
-The architecture follow the diagram below. For concrete usage examples please refer to the [crate's documentation](https://crates.io/crates/kadcast)
+The architecture follows the diagram below. For usage examples please refer to the [crate's documentation](https://crates.io/crates/kadcast)
 
 ![architecture](architecture.jpg)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,5 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - RaptorQ as Forward Error Correction.
 - Examples in `example` dir
 
+[#57]: https://github.com/dusk-network/kadcast/issues/57
 [#60]: https://github.com/dusk-network/kadcast/issues/60
-[#60]: https://github.com/dusk-network/kadcast/issues/63
+[#63]: https://github.com/dusk-network/kadcast/issues/63

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `auto_propagate` flag to Peer [#57]
+- Add optional `height` parameter to `broadcast` method [#57]
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `auto_propagate` flag to Peer [#57]
+
 ### Changed
 
 - Change `on_message` callback into a trait [#63]

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -88,7 +88,7 @@ pub async fn main() {
                 "report" => {
                     peer.report().await;
                 }
-                v => peer.broadcast(v.as_bytes()).await,
+                v => peer.broadcast(v.as_bytes(), None).await,
             }
         }
     }

--- a/src/handling.rs
+++ b/src/handling.rs
@@ -25,6 +25,7 @@ impl MessageHandler {
         mut inbound_receiver: Receiver<MessageBeanIn>,
         outbound_sender: Sender<MessageBeanOut>,
         listener_sender: Sender<Vec<u8>>,
+        auto_broadcast: bool,
     ) {
         tokio::spawn(async move {
             debug!("MessageHandler started");
@@ -112,7 +113,7 @@ impl MessageHandler {
                                 error!("Unable to notify client {:?}", op)
                             });
                         let table_read = ktable.read().await;
-                        if payload.height > 0 {
+                        if payload.height > 0 && auto_broadcast {
                             debug!(
                                 "Extracting for height {:?}",
                                 payload.height - 1

--- a/src/handling.rs
+++ b/src/handling.rs
@@ -112,37 +112,39 @@ impl MessageHandler {
                             .unwrap_or_else(|op| {
                                 error!("Unable to notify client {:?}", op)
                             });
-                        let table_read = ktable.read().await;
-                        if payload.height > 0 && auto_broadcast {
-                            debug!(
-                                "Extracting for height {:?}",
-                                payload.height - 1
-                            );
+                        if auto_broadcast {
+                            let table_read = ktable.read().await;
+                            if payload.height > 0 {
+                                debug!(
+                                    "Extracting for height {:?}",
+                                    payload.height - 1
+                                );
 
-                            table_read
-                                .extract(Some((payload.height - 1).into()))
-                                .for_each(|(height, nodes)| {
-                                    let msg = Message::Broadcast(
-                                        my_header,
-                                        BroadcastPayload {
-                                            height: height.try_into().unwrap(),
-                                            gossip_frame: payload
-                                                .gossip_frame
-                                                .clone(), //FIX_ME: avoid clone
-                                        },
-                                    );
-                                    let targets: Vec<SocketAddr> = nodes
-                                        .map(|node| *node.value().address())
-                                        .collect();
-                                    outbound_sender
-                                        .try_send((msg, targets))
-                                        .unwrap_or_else(|op| {
-                                            error!(
-                                                "Unable to send broadcast {:?}",
-                                                op
-                                            )
-                                        });
-                                });
+                                table_read
+                                    .extract(Some((payload.height - 1).into()))
+                                    .for_each(|(height, nodes)| {
+                                        let msg = Message::Broadcast(
+                                            my_header,
+                                            BroadcastPayload {
+                                                height: height.try_into().unwrap(),
+                                                gossip_frame: payload
+                                                    .gossip_frame
+                                                    .clone(), //FIX_ME: avoid clone
+                                            },
+                                        );
+                                        let targets: Vec<SocketAddr> = nodes
+                                            .map(|node| *node.value().address())
+                                            .collect();
+                                        outbound_sender
+                                            .try_send((msg, targets))
+                                            .unwrap_or_else(|op| {
+                                                error!(
+                                                    "Unable to send broadcast {:?}",
+                                                    op
+                                                )
+                                            });
+                                    });
+                            }
                         }
                     }
                 }

--- a/src/handling.rs
+++ b/src/handling.rs
@@ -114,7 +114,6 @@ impl MessageHandler {
                             });
                         if auto_propagate && payload.height > 0 {
                             let table_read = ktable.read().await;
-                            
                             debug!(
                                 "Extracting for height {:?}",
                                 payload.height - 1
@@ -144,7 +143,6 @@ impl MessageHandler {
                                             )
                                         });
                                 });
-                            
                         }
                     }
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,7 +218,10 @@ impl<L: NetworkListen + 'static> PeerBuilder<L> {
     /// Enable automatic propagation of incoming broadcast messages
     ///
     /// Default value [ENABLE_BROADCAST_PROPAGATION]
-    pub fn with_auto_propagate(mut self, auto_propagate: bool) -> PeerBuilder<L> {
+    pub fn with_auto_propagate(
+        mut self,
+        auto_propagate: bool,
+    ) -> PeerBuilder<L> {
         self.auto_propagate = auto_propagate;
         self
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,9 +33,9 @@ const K_DIFF_MIN_BIT: usize = 8;
 const K_DIFF_PRODUCED_BIT: usize = 8;
 const MAX_DATAGRAM_SIZE: usize = 65_507;
 
-//Redundacy factor for lookup
+// Redundacy factor for lookup
 const K_ALPHA: usize = 3;
-//Redundacy factor for broadcast
+// Redundacy factor for broadcast
 const K_BETA: usize = 3;
 
 const K_CHUNK_SIZE: u16 = 1024;
@@ -49,6 +49,9 @@ pub const BUCKET_DEFAULT_NODE_EVICT_AFTER_MILLIS: u64 = 5000;
 
 /// Default value after which a bucket is considered idle
 pub const BUCKET_DEFAULT_TTL_SECS: u64 = 60 * 60;
+
+/// Default behaviour for propagation of broadcast messages
+pub const ENABLE_BROADCAST_PROPAGATION: bool = true;
 
 /// Struct representing the Kadcast Network Peer
 pub struct Peer {
@@ -83,6 +86,7 @@ impl Peer {
             inbound_channel_rx,
             outbound_channel_tx.clone(),
             notification_channel_tx,
+            auto_broadcast,
         );
         tokio::spawn(WireNetwork::start(
             inbound_channel_tx,
@@ -175,6 +179,7 @@ pub struct PeerBuilder<L: NetworkListen + 'static> {
     node_ttl: Duration,
     node_evict_after: Duration,
     bucket_ttl: Duration,
+    auto_broadcast: bool,
     public_ip: String,
     bootstrapping_nodes: Vec<String>,
     listener: L,
@@ -209,6 +214,14 @@ impl<L: NetworkListen + 'static> PeerBuilder<L> {
         self
     }
 
+    /// Enable automatic propagation of received broadcast messages
+    ///
+    /// Default value [ENABLE_BROADCAST_PROPAGATION]
+    pub fn with_auto_broadcast(mut self, auto_broadcast: bool) -> PeerBuilder {
+        self.auto_broadcast = auto_broadcast;
+        self
+    }
+
     fn new(
         public_ip: String,
         bootstrapping_nodes: Vec<String>,
@@ -224,6 +237,7 @@ impl<L: NetworkListen + 'static> PeerBuilder<L> {
             ),
             node_ttl: Duration::from_millis(BUCKET_DEFAULT_NODE_TTL_MILLIS),
             bucket_ttl: Duration::from_secs(BUCKET_DEFAULT_TTL_SECS),
+            auto_broadcast: ENABLE_BROADCAST_PROPAGATION,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,15 +139,15 @@ impl Peer {
     /// Note:
     /// The function returns just after the message is put on the internal queue
     /// system. It **does not guarantee** the message will be broadcasted
-    pub async fn broadcast(&self, message: &[u8]) {
+    pub async fn broadcast(&self, message: &[u8], height: Option<usize>) {
         if message.is_empty() {
             return;
         }
-        for (height, nodes) in self.ktable.read().await.extract(None) {
+        for (h, nodes) in self.ktable.read().await.extract(height) {
             let msg = Message::Broadcast(
                 self.ktable.read().await.root().as_header(),
                 BroadcastPayload {
-                    height: height.try_into().unwrap(),
+                    height: h.try_into().unwrap(),
                     gossip_frame: message.to_vec(), //FIX_ME: avoid clone
                 },
             );


### PR DESCRIPTION
Adding a flag to prevent (upon will) received broadcast messages from being auto-propagated to other nodes.

Closes #57 