### PR TITLE
Added send method to Peer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `auto_propagate` flag to Peer [#57]
-<<<<<<< HEAD
 - Add optional `height` parameter to `broadcast` method [#57]
-=======
 - Add `send` method to public API [#58]
->>>>>>> Add send method to Peer
 
 ### Changed
 
@@ -35,6 +32,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Examples in `example` dir
 
 [#57]: https://github.com/dusk-network/kadcast/issues/57
-[#58]: https://github.com/dusk-network/kadcast/issues/57
+[#58]: https://github.com/dusk-network/kadcast/issues/58
 [#60]: https://github.com/dusk-network/kadcast/issues/60
 [#63]: https://github.com/dusk-network/kadcast/issues/63

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `auto_propagate` flag to Peer [#57]
+<<<<<<< HEAD
 - Add optional `height` parameter to `broadcast` method [#57]
+=======
+- Add `send` method to public API [#58]
+>>>>>>> Add send method to Peer
 
 ### Changed
 
@@ -31,5 +35,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Examples in `example` dir
 
 [#57]: https://github.com/dusk-network/kadcast/issues/57
+[#58]: https://github.com/dusk-network/kadcast/issues/57
 [#60]: https://github.com/dusk-network/kadcast/issues/60
 [#63]: https://github.com/dusk-network/kadcast/issues/63


### PR DESCRIPTION
As per #58 we add a `send` method to the public `Peer` API.

We agree to use the `Broadcast` type for messages, setting `height` to `0` as a neat trick to prevent propagation at the receiver's end, thus removing the need for extra message types or processing logic.

Closes #58 