### PR TITLE
Add metadata to on_message callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `auto_propagate` flag to Peer [#57]
 - Add optional `height` parameter to `broadcast` method [#57]
 - Add `send` method to public API [#58]
+- Add metadata to `on_message` callback [#59]
 
 ### Changed
 
@@ -33,5 +34,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#57]: https://github.com/dusk-network/kadcast/issues/57
 [#58]: https://github.com/dusk-network/kadcast/issues/58
+[#59]: https://github.com/dusk-network/kadcast/issues/59
 [#60]: https://github.com/dusk-network/kadcast/issues/60
 [#63]: https://github.com/dusk-network/kadcast/issues/63

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -5,7 +5,7 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use clap::{App, Arg};
-use kadcast::{NetworkListen, Peer};
+use kadcast::{MessageInfo, NetworkListen, Peer};
 use rustc_tools_util::{get_version_info, VersionInfo};
 use std::io::{self, BufRead};
 
@@ -95,11 +95,13 @@ pub async fn main() {
 }
 pub struct DummyListener {}
 impl NetworkListen for DummyListener {
-    fn on_message(&self, message: Vec<u8>) {
+    fn on_message(&self, message: Vec<u8>, md: MessageInfo) {
         println!(
-            "Received {}",
+            "Received {} from {} (height: {})",
             String::from_utf8(message.to_vec())
-                .unwrap_or_else(|_| "No UTF8 message received".to_string())
+                .unwrap_or_else(|_| "No UTF8 message received".to_string()),
+            md.src(),
+            md.height(),
         );
     }
 }


### PR DESCRIPTION
Added metadata to `on_message` callback as per #59 

Added a `MessageInfo` struct within `encoding` module because imho it made sense for it to be there with other `Message`, `Header`, `Payload`, and other related types.

Using a tuple for actual message passing through the notification channel.