### PR TITLE
Parametrize RaptorQ configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Add network transport configuration [#72]
 
 ## [0.2.0] - 16-12-21
 
@@ -42,3 +45,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#63]: https://github.com/dusk-network/kadcast/issues/63
 [#68]: https://github.com/dusk-network/kadcast/issues/68
 [#69]: https://github.com/dusk-network/kadcast/issues/69
+[#72]: https://github.com/dusk-network/kadcast/issues/72

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kadcast"
-version = "0.2.0"
+version = "0.2.1"
 authors = [
   "herr-seppia <seppia@dusk.network>"
 ]

--- a/HEADER_TEMPLATE
+++ b/HEADER_TEMPLATE
@@ -1,0 +1,6 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -88,10 +88,13 @@ pub async fn main() {
         .map(|s| s.to_string())
         .collect();
 
-    let peer =
+    let mut builder =
         Peer::builder(public_address, bootstrapping_nodes, DummyListener {})
-            .with_listen_address(listen_address)
-            .build();
+            .with_listen_address(listen_address);
+    builder
+        .transport_conf()
+        .extend(kadcast::transport::default_configuration());
+    let peer = builder.build();
     loop {
         let stdin = io::stdin();
         for message in stdin.lock().lines().flatten() {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,4 @@
 max_width = 80
 newline_style = "Unix"
 wrap_comments = true
+license_template_path = "HEADER_TEMPLATE"

--- a/src/transport/encoding.rs
+++ b/src/transport/encoding.rs
@@ -9,13 +9,14 @@ mod raptorq;
 
 use std::collections::HashMap;
 
-pub(crate) use self::raptorq::RaptorQDecoder;
-pub(crate) use self::raptorq::RaptorQEncoder;
+pub(crate) use self::raptorq::RaptorQDecoder as TransportDecoder;
+pub(crate) use self::raptorq::RaptorQEncoder as TransportEncoder;
 
 use crate::encoding::message::Message;
 
 pub(crate) trait Configurable {
-    fn configure(conf: HashMap<String, String>) -> Self;
+    fn configure(conf: &HashMap<String, String>) -> Self;
+    fn default_configuration() -> HashMap<String, String>;
 }
 
 pub(crate) trait Encoder: Configurable {

--- a/src/transport/encoding.rs
+++ b/src/transport/encoding.rs
@@ -7,11 +7,21 @@
 mod plain_encoder;
 mod raptorq_encoder;
 
+use std::collections::HashMap;
+
+pub(crate) use raptorq_encoder::RaptorQDecoder;
 pub(crate) use raptorq_encoder::RaptorQEncoder;
 
 use crate::encoding::message::Message;
-pub(crate) trait Encoder {
-    fn encode(msg: Message) -> Vec<Message>;
 
+pub(crate) trait Configurable {
+    fn configure(conf: HashMap<String, String>) -> Self;
+}
+
+pub(crate) trait Encoder: Configurable {
+    fn encode(&self, msg: Message) -> Vec<Message>;
+}
+
+pub(crate) trait Decoder: Configurable {
     fn decode(&mut self, chunk: Message) -> Option<Message>;
 }

--- a/src/transport/encoding.rs
+++ b/src/transport/encoding.rs
@@ -5,12 +5,12 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 mod plain_encoder;
-mod raptorq_encoder;
+mod raptorq;
 
 use std::collections::HashMap;
 
-pub(crate) use raptorq_encoder::RaptorQDecoder;
-pub(crate) use raptorq_encoder::RaptorQEncoder;
+pub(crate) use self::raptorq::RaptorQDecoder;
+pub(crate) use self::raptorq::RaptorQEncoder;
 
 use crate::encoding::message::Message;
 

--- a/src/transport/encoding/plain_encoder.rs
+++ b/src/transport/encoding/plain_encoder.rs
@@ -4,17 +4,27 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+use std::{collections::HashMap};
+
 use crate::encoding::message::Message;
 
-use super::Encoder;
+use super::{Configurable, Decoder, Encoder};
 
 pub(crate) struct PlainEncoder {}
 
+impl Configurable for PlainEncoder {
+    fn configure(_: HashMap<String, String>) -> Self {
+        PlainEncoder {}
+    }
+}
+
 impl Encoder for PlainEncoder {
-    fn encode<'msg>(msg: Message) -> Vec<Message> {
+    fn encode<'msg>(&self, msg: Message) -> Vec<Message> {
         vec![msg]
     }
+}
 
+impl Decoder for PlainEncoder {
     fn decode(&mut self, chunk: Message) -> Option<Message> {
         if let Message::Broadcast(header, payload) = chunk {
             Some(Message::Broadcast(header, payload))

--- a/src/transport/encoding/plain_encoder.rs
+++ b/src/transport/encoding/plain_encoder.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use std::{collections::HashMap};
+use std::collections::HashMap;
 
 use crate::encoding::message::Message;
 

--- a/src/transport/encoding/plain_encoder.rs
+++ b/src/transport/encoding/plain_encoder.rs
@@ -13,8 +13,11 @@ use super::{Configurable, Decoder, Encoder};
 pub(crate) struct PlainEncoder {}
 
 impl Configurable for PlainEncoder {
-    fn configure(_: HashMap<String, String>) -> Self {
+    fn configure(_: &HashMap<String, String>) -> Self {
         PlainEncoder {}
+    }
+    fn default_configuration() -> HashMap<String, String> {
+        HashMap::new()
     }
 }
 

--- a/src/transport/encoding/raptorq.rs
+++ b/src/transport/encoding/raptorq.rs
@@ -1,0 +1,76 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use std::convert::TryInto;
+
+use blake2::{Blake2s, Digest};
+use raptorq::ObjectTransmissionInformation;
+
+use crate::encoding::{payload::BroadcastPayload, Marshallable};
+
+mod decoder;
+mod encoder;
+
+pub(crate) use decoder::RaptorQDecoder;
+pub(crate) use encoder::RaptorQEncoder;
+
+struct ChunkedPayload<'a>(&'a BroadcastPayload);
+
+impl BroadcastPayload {
+    fn bytes(&self) -> Vec<u8> {
+        let mut bytes = vec![];
+        self.marshal_binary(&mut bytes).unwrap();
+        bytes
+    }
+    fn generate_uid(&self) -> [u8; 32] {
+        let mut hasher = Blake2s::new();
+        hasher.update(&self.bytes()[1..]);
+        hasher
+            .finalize()
+            .as_slice()
+            .try_into()
+            .expect("Wrong length")
+    }
+}
+impl<'a> ChunkedPayload<'a> {
+    fn uid(&self) -> [u8; 32] {
+        let mut uid: [u8; 32] = Default::default();
+        uid.copy_from_slice(&self.0.gossip_frame[0..32]);
+        uid
+    }
+
+    fn transmission_info(&self) -> ObjectTransmissionInformation {
+        let mut transmission_info: [u8; 12] = Default::default();
+        transmission_info.copy_from_slice(&self.0.gossip_frame[32..44]);
+        ObjectTransmissionInformation::deserialize(&transmission_info)
+    }
+
+    fn encoded_chunk(&self) -> &[u8] {
+        &self.0.gossip_frame[44..]
+    }
+
+    fn safe_uid(&self) -> [u8; 32] {
+        let mut hasher = Blake2s::new();
+        let uid = &self.0.gossip_frame[0..32];
+        let transmission_info = &self.0.gossip_frame[32..44];
+        hasher.update(uid);
+
+        // Why do we need transmission info?
+        //
+        // Transmission info should be sent over a reliable channel, because
+        // it is critical to decode packets.
+        // Since it is sent over UDP alongside the encoded chunked bytes,
+        // corrupted transmission info can be received.
+        // If the corrupted info is part of the first received chunk, no message
+        // can ever be decoded.
+        hasher.update(transmission_info);
+        hasher
+            .finalize()
+            .as_slice()
+            .try_into()
+            .expect("Wrong length")
+    }
+}

--- a/src/transport/encoding/raptorq/decoder.rs
+++ b/src/transport/encoding/raptorq/decoder.rs
@@ -4,26 +4,18 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+use crate::transport::{encoding::Configurable, Decoder};
+use raptorq::{Decoder as ExtDecoder, EncodingPacket};
 use std::{
     collections::HashMap,
-    convert::TryInto,
     time::{Duration, Instant},
-};
-
-use blake2::{Blake2s, Digest};
-use raptorq::{
-    Decoder, Encoder, EncodingPacket, ObjectTransmissionInformation,
 };
 use tracing::warn;
 
-use crate::encoding::{
-    message::Message, payload::BroadcastPayload, Marshallable,
-};
+use crate::encoding::{message::Message, payload::BroadcastPayload};
 
-use super::Configurable;
+use super::ChunkedPayload;
 
-const DEFAULT_REPAIR_PACKETS_PER_BLOCK: u32 = 15;
-const MAX_CHUNK_SIZE: u16 = 1024;
 const CACHE_DEFAULT_TTL_SECS: u64 = 60;
 const CACHE_PRUNED_EVERY_SECS: u64 = 60 * 5;
 
@@ -45,15 +37,8 @@ impl Configurable for RaptorQDecoder {
     }
 }
 
-pub(crate) struct RaptorQEncoder {}
-
-impl Configurable for RaptorQEncoder {
-    fn configure(_: HashMap<String, String>) -> Self {
-        Self {}
-    }
-}
 enum CacheStatus {
-    Receiving(Decoder, Instant),
+    Receiving(ExtDecoder, Instant),
     Processed(Instant),
 }
 
@@ -68,94 +53,7 @@ impl CacheStatus {
     }
 }
 
-struct ChunkedPayload<'a>(&'a BroadcastPayload);
-
-impl BroadcastPayload {
-    fn bytes(&self) -> Vec<u8> {
-        let mut bytes = vec![];
-        self.marshal_binary(&mut bytes).unwrap();
-        bytes
-    }
-    fn generate_uid(&self) -> [u8; 32] {
-        let mut hasher = Blake2s::new();
-        hasher.update(&self.bytes()[1..]);
-        hasher
-            .finalize()
-            .as_slice()
-            .try_into()
-            .expect("Wrong length")
-    }
-}
-impl<'a> ChunkedPayload<'a> {
-    fn uid(&self) -> [u8; 32] {
-        let mut uid: [u8; 32] = Default::default();
-        uid.copy_from_slice(&self.0.gossip_frame[0..32]);
-        uid
-    }
-
-    fn transmission_info(&self) -> ObjectTransmissionInformation {
-        let mut transmission_info: [u8; 12] = Default::default();
-        transmission_info.copy_from_slice(&self.0.gossip_frame[32..44]);
-        ObjectTransmissionInformation::deserialize(&transmission_info)
-    }
-
-    fn encoded_chunk(&self) -> &[u8] {
-        &self.0.gossip_frame[44..]
-    }
-
-    fn safe_uid(&self) -> [u8; 32] {
-        let mut hasher = Blake2s::new();
-        let uid = &self.0.gossip_frame[0..32];
-        let transmission_info = &self.0.gossip_frame[32..44];
-        hasher.update(uid);
-
-        // Why do we need transmission info?
-        //
-        // Transmission info should be sent over a reliable channel, because
-        // it is critical to decode packets.
-        // Since it is sent over UDP alongside the encoded chunked bytes,
-        // corrupted transmission info can be received.
-        // If the corrupted info is part of the first received chunk, no message
-        // can ever be decoded.
-        hasher.update(transmission_info);
-        hasher
-            .finalize()
-            .as_slice()
-            .try_into()
-            .expect("Wrong length")
-    }
-}
-
-impl super::Encoder for RaptorQEncoder {
-    fn encode<'msg>(&self, msg: Message) -> Vec<Message> {
-        if let Message::Broadcast(header, payload) = msg {
-            let uid = payload.generate_uid();
-            let encoder =
-                Encoder::with_defaults(&payload.gossip_frame, MAX_CHUNK_SIZE);
-            encoder
-                .get_encoded_packets(DEFAULT_REPAIR_PACKETS_PER_BLOCK)
-                .iter()
-                .map(|encoded_packet| {
-                    let mut packet_with_uid = uid.to_vec();
-                    let mut transmission_info =
-                        encoder.get_config().serialize().to_vec();
-                    packet_with_uid.append(&mut transmission_info);
-                    packet_with_uid.append(&mut encoded_packet.serialize());
-                    Message::Broadcast(
-                        header,
-                        BroadcastPayload {
-                            height: payload.height,
-                            gossip_frame: packet_with_uid,
-                        },
-                    )
-                })
-                .collect()
-        } else {
-            vec![msg]
-        }
-    }
-}
-impl super::Decoder for RaptorQDecoder {
+impl Decoder for RaptorQDecoder {
     fn decode(&mut self, message: Message) -> Option<Message> {
         if let Message::Broadcast(header, payload) = message {
             let chunked = ChunkedPayload(&payload);
@@ -171,7 +69,7 @@ impl super::Decoder for RaptorQDecoder {
                 // the received transmission information
                 std::collections::hash_map::Entry::Vacant(v) => {
                     v.insert(CacheStatus::Receiving(
-                        Decoder::new(chunked.transmission_info()),
+                        ExtDecoder::new(chunked.transmission_info()),
                         Instant::now(),
                     ))
                 }

--- a/src/transport/encoding/raptorq/encoder.rs
+++ b/src/transport/encoding/raptorq/encoder.rs
@@ -1,0 +1,57 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use crate::transport::Encoder;
+use std::collections::HashMap;
+
+use crate::encoding::{message::Message, payload::BroadcastPayload};
+
+use super::super::Configurable;
+
+const DEFAULT_REPAIR_PACKETS_PER_BLOCK: u32 = 15;
+const MAX_CHUNK_SIZE: u16 = 1024;
+
+use raptorq::Encoder as ExtEncoder;
+
+pub(crate) struct RaptorQEncoder {}
+
+impl Configurable for RaptorQEncoder {
+    fn configure(_: HashMap<String, String>) -> Self {
+        Self {}
+    }
+}
+
+impl Encoder for RaptorQEncoder {
+    fn encode<'msg>(&self, msg: Message) -> Vec<Message> {
+        if let Message::Broadcast(header, payload) = msg {
+            let uid = payload.generate_uid();
+            let encoder = ExtEncoder::with_defaults(
+                &payload.gossip_frame,
+                MAX_CHUNK_SIZE,
+            );
+            encoder
+                .get_encoded_packets(DEFAULT_REPAIR_PACKETS_PER_BLOCK)
+                .iter()
+                .map(|encoded_packet| {
+                    let mut packet_with_uid = uid.to_vec();
+                    let mut transmission_info =
+                        encoder.get_config().serialize().to_vec();
+                    packet_with_uid.append(&mut transmission_info);
+                    packet_with_uid.append(&mut encoded_packet.serialize());
+                    Message::Broadcast(
+                        header,
+                        BroadcastPayload {
+                            height: payload.height,
+                            gossip_frame: packet_with_uid,
+                        },
+                    )
+                })
+                .collect()
+        } else {
+            vec![msg]
+        }
+    }
+}


### PR DESCRIPTION
Enable arbitrary configuration for any Encoder

- Split `Encoder` in two different traits (`Encoder`/`Decoder`)
- Add `Configurable` trait

Resolves #72