### PR TITLE
Allow K_K env! override

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kadcast"
-version = "0.2.0"
+version = "0.2.1"
 authors = [
   "herr-seppia <seppia@dusk.network>"
 ]
@@ -25,6 +25,7 @@ tokio = { version = "1", features = ["rt", "net", "sync", "time", "io-std", "rt-
 raptorq = "1.6"
 tracing = "0.1"
 itertools = "0.10"
+konst = "0.2"
 
 [dev-dependencies]
 clap = "2.33.3"

--- a/src/kbucket.rs
+++ b/src/kbucket.rs
@@ -15,7 +15,7 @@ pub use node::Node;
 
 pub use bucket::InsertError;
 pub use bucket::InsertOk;
-use tracing::debug;
+use tracing::info;
 
 mod bucket;
 mod key;
@@ -159,7 +159,11 @@ impl<V> TreeBuilder<V> {
     }
 
     pub(crate) fn build(self) -> Tree<V> {
-        debug!("Built table with root: {:?}", self.root.id());
+        info!(
+            "Built table [K={}] with root: {:?}",
+            crate::K_K,
+            self.root.id()
+        );
         Tree {
             root: self.root,
             buckets: HashMap::new(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,12 +27,23 @@ mod peer;
 mod transport;
 
 // Max amount of nodes a bucket should contain
-const K_K: usize = 20;
+const DEFAULT_K_K: usize = 20;
+const K_K: usize = get_k_k();
 const K_ID_LEN_BYTES: usize = 16;
 const K_NONCE_LEN: usize = 4;
 const K_DIFF_MIN_BIT: usize = 8;
 const K_DIFF_PRODUCED_BIT: usize = 8;
 const MAX_DATAGRAM_SIZE: usize = 65_507;
+
+const fn get_k_k() -> usize {
+    match option_env!("KADCAST_K") {
+        Some(v) => match konst::primitive::parse_usize(v) {
+            Ok(e) => e,
+            Err(_) => DEFAULT_K_K,
+        },
+        None => DEFAULT_K_K,
+    }
+}
 
 // Redundacy factor for lookup
 const K_ALPHA: usize = 3;


### PR DESCRIPTION
The default `K_K` value could be override using the env `KADCAST_K`

Resolves #74