### PR TITLE
Improve network discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add network transport configuration [#72] [#76]
+- Add recursive NetworkDiscovery configuration [#78]
+- Add internal channel capacity configuration [#78]
 
 ## [0.2.0] - 16-12-21
 
@@ -47,3 +49,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#69]: https://github.com/dusk-network/kadcast/issues/69
 [#72]: https://github.com/dusk-network/kadcast/issues/72
 [#76]: https://github.com/dusk-network/kadcast/issues/76
+[#78]: https://github.com/dusk-network/kadcast/issues/78

--- a/src/kbucket.rs
+++ b/src/kbucket.rs
@@ -119,6 +119,25 @@ impl<V> Tree<V> {
             .filter(move |(_, bucket)| bucket.is_idle())
             .map(|(&height, bucket)| (height, bucket.pick::<K_ALPHA>()))
     }
+
+    pub(crate) fn has_peer(&self, peer: &BinaryKey) -> Option<usize> {
+        match self.root.id().calculate_distance(peer) {
+            None => None,
+            Some(height) => self.buckets.get(&height).and_then(|bucket| {
+                if bucket.has_node(peer) {
+                    Some(height)
+                } else {
+                    None
+                }
+            }),
+        }
+    }
+
+    pub(crate) fn is_bucket_full(&self, height: usize) -> bool {
+        self.buckets
+            .get(&height)
+            .map_or(false, |bucket| bucket.is_full())
+    }
 }
 
 pub struct TreeBuilder<V> {

--- a/src/kbucket/bucket.rs
+++ b/src/kbucket/bucket.rs
@@ -201,6 +201,14 @@ impl<V> Bucket<V> {
             self.nodes.truncate(idx)
         }
     }
+
+    pub(crate) fn has_node(&self, peer: &BinaryKey) -> bool {
+        self.nodes.iter().any(|n| n.id().as_binary() == peer)
+    }
+
+    pub(crate) fn is_full(&self) -> bool {
+        self.nodes.is_full()
+    }
 }
 
 #[cfg(test)]

--- a/src/mantainer.rs
+++ b/src/mantainer.rs
@@ -64,6 +64,7 @@ impl TableMantainer {
                             root.as_header(),
                             *target.id().as_binary(),
                         ),
+                        //TODO: Extract alpha nodes
                         vec![*target.value().address()],
                     )
                 });

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -112,6 +112,7 @@ impl WireNetwork {
         let encoder = TransportEncoder::configure(conf);
         loop {
             if let Some((message, to)) = outbound_channel_rx.recv().await {
+                trace!("< Message to send to ({:?}) - {:?} ", to, message);
                 let chunks: Vec<Vec<u8>> =
                     encoder.encode(message).iter().map(|m| m.bytes()).collect();
                 for remote_addr in to.iter() {

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -29,7 +29,7 @@ pub(crate) struct WireNetwork {}
 mod encoding;
 
 impl WireNetwork {
-    pub async fn start(
+    pub fn start(
         inbound_channel_tx: Sender<MessageBeanIn>,
         listen_address: String,
         outbound_channel_rx: Receiver<MessageBeanOut>,
@@ -38,13 +38,21 @@ impl WireNetwork {
         let listen_address = listen_address
             .parse()
             .expect("Unable to parse public_ip address");
-        let a = WireNetwork::listen_out(outbound_channel_rx, &conf);
-        let b = WireNetwork::listen_in(
-            listen_address,
-            inbound_channel_tx.clone(),
-            &conf,
-        );
-        let _ = tokio::join!(a, b);
+        let c = conf.clone();
+        tokio::spawn(async move {
+            WireNetwork::listen_out(outbound_channel_rx, &c)
+                .await
+                .unwrap_or_else(|op| error!("Error in listen_out {:?}", op));
+        });
+        tokio::spawn(async move {
+            WireNetwork::listen_in(
+                listen_address,
+                inbound_channel_tx.clone(),
+                &conf,
+            )
+            .await
+            .unwrap_or_else(|op| error!("Error in listen_in {:?}", op));
+        });
     }
 
     async fn listen_in(
@@ -104,12 +112,12 @@ impl WireNetwork {
         let encoder = TransportEncoder::configure(conf);
         loop {
             if let Some((message, to)) = outbound_channel_rx.recv().await {
-                trace!("< Message to send to ({:?}) - {:?} ", to, message);
-                for chunk in encoder.encode(message).iter() {
-                    let bytes = chunk.bytes();
-                    for remote_addr in to.iter() {
+                let chunks: Vec<Vec<u8>> =
+                    encoder.encode(message).iter().map(|m| m.bytes()).collect();
+                for remote_addr in to.iter() {
+                    for chunk in &chunks {
                         output_sockets
-                            .send(&bytes, remote_addr)
+                            .send(chunk, remote_addr)
                             .await
                             .unwrap_or_else(|e| {
                                 warn!("Unable to send msg {}", e)


### PR DESCRIPTION
- Refactor `Nodes` message handling
- Allow to turn off recursive NetworkDiscovery
  (use Ping instead of FindNodes)

- Allow to change internal channel capacity
- Send chunks to targets sequentially instead of roundrobin
- Handle WireNetwork faults
- Fix node bootstrap

Resolves #78