### PR TITLE
Remove unwrap/expect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed 
+- Change `Peer::new` to return a Result [#115]
+- Change `blake2` dependency from `0.9` to `0.10` [#115]
+
 ## [0.4.1] - 2022-07-27
 
 ### Added
@@ -101,6 +105,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#108]: https://github.com/dusk-network/kadcast/issues/108
 [#110]: https://github.com/dusk-network/kadcast/issues/110
 [#112]: https://github.com/dusk-network/kadcast/issues/112
+[#115]: https://github.com/dusk-network/kadcast/issues/115
 
 <!-- Releases -->
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [".git*", "ARCHITECTURE.md", "architecture.jpg"]
 
 [dependencies]
 arrayvec = "0.7"
-blake2 = "0.9"
+blake2 = "0.10"
 rand = "0.8"
 tokio = { version = "1", features = ["rt", "net", "sync", "time", "io-std", "rt-multi-thread", "macros"] }
 raptorq = "1.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
 name = "kadcast"
 authors = ["herr-seppia <seppia@dusk.network>"]
-version = "0.4.1"
+version = "0.5.0-rc.0"
 edition = "2018"
 description = "Implementation of the Kadcast Network Protocol."
 categories = ["network-programming"]
 keywords = ["p2p", "network", "kad", "peer-to-peer", "kadcast"]
 license = "MPL-2.0"
 repository = "https://github.com/dusk-network/kadcast"
+publish = false
 
 exclude = [".git*", "ARCHITECTURE.md", "architecture.jpg"]
 

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -4,21 +4,22 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+use std::error::Error;
+use std::io::{self, BufRead};
+
 use clap::{App, Arg};
 use kadcast::config::Config;
 use kadcast::{MessageInfo, NetworkListen, Peer};
 use rustc_tools_util::{get_version_info, VersionInfo};
-use std::io::{self, BufRead};
+use serde_derive::{Deserialize, Serialize};
 
-use serde_derive::Deserialize;
-use serde_derive::Serialize;
 #[derive(Serialize, Deserialize)]
 struct General {
     kadcast: kadcast::config::Config,
 }
 
 #[tokio::main]
-pub async fn main() {
+pub async fn main() -> Result<(), Box<dyn Error>> {
     let crate_info = get_version_info!();
     let matches = App::new(&crate_info.crate_name)
         .version(show_version(crate_info).as_str())
@@ -85,8 +86,10 @@ pub async fn main() {
         .expect("Failed on subscribe tracing");
 
     let mut conf = Config::default();
-    conf.public_address =
-        matches.value_of("public_address").unwrap().to_string();
+    conf.public_address = matches
+        .value_of("public_address")
+        .expect("public_address to have a value")
+        .to_string();
     conf.listen_address =
         matches.value_of("listen_address").map(|a| a.to_string());
     conf.bootstrapping_nodes = matches
@@ -95,7 +98,7 @@ pub async fn main() {
         .map(|s| s.to_string())
         .collect();
 
-    let peer = Peer::new(conf, DummyListener {});
+    let peer = Peer::new(conf, DummyListener {})?;
     loop {
         let stdin = io::stdin();
         for message in stdin.lock().lines().flatten() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,13 +4,16 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use crate::transport::encoding::Configurable;
-use crate::transport::encoding::TransportDecoder;
-pub use crate::transport::encoding::TransportDecoderConfig;
-use crate::transport::encoding::TransportEncoder;
-pub use crate::transport::encoding::TransportEncoderConfig;
-use serde_derive::{Deserialize, Serialize};
 use std::time::Duration;
+
+use serde_derive::{Deserialize, Serialize};
+
+use crate::transport::encoding::{
+    Configurable, TransportDecoder, TransportEncoder,
+};
+pub use crate::transport::encoding::{
+    TransportDecoderConfig, TransportEncoderConfig,
+};
 
 /// Default value while a node is considered alive (no eviction will be
 /// requested)

--- a/src/encoding/header.rs
+++ b/src/encoding/header.rs
@@ -6,9 +6,9 @@
 
 use std::io::{self, Error, ErrorKind, Read, Write};
 
+use super::Marshallable;
 use crate::{kbucket::BinaryID, K_ID_LEN_BYTES, K_NONCE_LEN};
 
-use super::Marshallable;
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub struct Header {
     pub(crate) binary_id: BinaryID,

--- a/src/encoding/message.rs
+++ b/src/encoding/message.rs
@@ -6,10 +6,9 @@
 
 use std::io::{self, Error, ErrorKind, Read, Write};
 
-use crate::kbucket::BinaryKey;
-
 pub(crate) use super::payload::{BroadcastPayload, NodePayload};
 pub use super::{header::Header, Marshallable};
+use crate::kbucket::BinaryKey;
 
 // PingMsg wire Ping message id.
 const ID_MSG_PING: u8 = 0;
@@ -56,10 +55,10 @@ impl Message {
         }
     }
 
-    pub(crate) fn bytes(&self) -> Vec<u8> {
+    pub(crate) fn bytes(&self) -> io::Result<Vec<u8>> {
         let mut bytes = vec![];
-        self.marshal_binary(&mut bytes).unwrap();
-        bytes
+        self.marshal_binary(&mut bytes)?;
+        Ok(bytes)
     }
 }
 

--- a/src/encoding/payload.rs
+++ b/src/encoding/payload.rs
@@ -6,7 +6,8 @@
 
 pub(super) mod broadcast;
 pub(super) mod nodes;
-pub(crate) use crate::encoding::payload::broadcast::BroadcastPayload;
-pub(crate) use crate::encoding::payload::nodes::NodePayload;
 pub use nodes::IpInfo;
 pub(crate) use nodes::PeerEncodedInfo;
+
+pub(crate) use crate::encoding::payload::broadcast::BroadcastPayload;
+pub(crate) use crate::encoding::payload::nodes::NodePayload;

--- a/src/encoding/payload/broadcast.rs
+++ b/src/encoding/payload/broadcast.rs
@@ -7,6 +7,7 @@
 use std::io::{self, Read, Write};
 
 use crate::encoding::Marshallable;
+
 #[derive(Debug, PartialEq)]
 pub(crate) struct BroadcastPayload {
     pub(crate) height: u8,

--- a/src/encoding/payload/nodes.rs
+++ b/src/encoding/payload/nodes.rs
@@ -9,6 +9,7 @@ use std::io::{self, Read, Write};
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 
 use crate::{encoding::Marshallable, kbucket::BinaryKey, K_ID_LEN_BYTES};
+
 #[derive(Debug, PartialEq)]
 pub(crate) struct NodePayload {
     pub(crate) peers: Vec<PeerEncodedInfo>,
@@ -74,7 +75,7 @@ impl Marshallable for PeerEncodedInfo {
                 let ipv6_bytes: [u8; 16] = concat_u8(&ipv4[1..], &ipv6[..])
                     .as_slice()
                     .try_into()
-                    .expect("Wrong length");
+                    .expect("ipv6_bytes to be length 16");
 
                 IpInfo::IPv6(ipv6_bytes)
             }

--- a/src/handling.rs
+++ b/src/handling.rs
@@ -4,7 +4,6 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use std::convert::TryInto;
 use std::net::SocketAddr;
 
 use tokio::sync::mpsc::{Receiver, Sender};
@@ -200,12 +199,12 @@ impl MessageHandler {
                             let table_read = ktable.read().await;
 
                             let messages: Vec<(Message, Vec<SocketAddr>)> = table_read
-                                .extract(Some((payload.height - 1).into()))
+                                .extract(Some(payload.height - 1))
                                 .map(|(height, nodes)| {
                                     let msg = Message::Broadcast(
                                         my_header,
                                         BroadcastPayload {
-                                            height: height.try_into().unwrap(),
+                                            height,
                                             gossip_frame: payload
                                                 .gossip_frame
                                                 .clone(), //FIX_ME: avoid clone

--- a/src/kbucket.rs
+++ b/src/kbucket.rs
@@ -165,15 +165,12 @@ impl<V> Tree<V> {
 mod tests {
     use std::time::Duration;
 
-    use crate::{
-        config::BucketConfig,
-        kbucket::{NodeInsertError, Tree},
-        peer::PeerNode,
-    };
-
+    use super::*;
+    use crate::peer::PeerNode;
+    use crate::tests::Result;
     #[test]
-    fn test_buckets() {
-        let root = PeerNode::generate("192.168.0.1:666");
+    fn test_buckets() -> Result<()> {
+        let root = PeerNode::generate("192.168.0.1:666")?;
         let mut config = BucketConfig::default();
         config.node_evict_after = Duration::from_millis(5000);
         config.node_ttl = Duration::from_secs(60);
@@ -182,7 +179,7 @@ mod tests {
         for i in 2..255 {
             let res = route_table.insert(PeerNode::generate(
                 &format!("192.168.0.{}:666", i)[..],
-            ));
+            )?);
             match res {
                 Ok(_) => {}
                 Err(error) => match error {
@@ -194,12 +191,13 @@ mod tests {
             }
         }
         let res = route_table
-            .insert(PeerNode::generate("192.168.0.1:666"))
+            .insert(PeerNode::generate("192.168.0.1:666")?)
             .expect_err("this should be an error");
         assert!(if let NodeInsertError::Invalid(_) = res {
             true
         } else {
             false
         });
+        Ok(())
     }
 }

--- a/src/kbucket/bucket.rs
+++ b/src/kbucket/bucket.rs
@@ -4,14 +4,14 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use crate::config::BucketConfig;
-use crate::K_K;
-
-use super::node::{Node, NodeEvictionStatus};
-use super::BinaryKey;
 use arrayvec::ArrayVec;
 use rand::seq::SliceRandom;
 use rand::thread_rng;
+
+use super::node::{Node, NodeEvictionStatus};
+use super::BinaryKey;
+use crate::config::BucketConfig;
+use crate::K_K;
 
 pub(super) struct Bucket<V> {
     nodes: arrayvec::ArrayVec<Node<V>, K_K>,
@@ -132,13 +132,17 @@ impl<V> Bucket<V> {
             self.try_perform_eviction();
             return Ok(NodeInsertOk::Updated {
                 pending_eviction: self.pending_eviction_node(),
-                updated: self.nodes.last().unwrap(),
+                updated: self.nodes.last().expect(
+                    "last node to exist because it's been just updated",
+                ),
             });
         }
         self.try_perform_eviction();
         match self.nodes.try_push(node) {
             Ok(_) => Ok(NodeInsertOk::Inserted {
-                inserted: self.nodes.last().unwrap(),
+                inserted: self.nodes.last().expect(
+                    "last node to exist because it's been just inserted",
+                ),
             }),
             Err(err) => {
                 if self

--- a/src/kbucket/bucket.rs
+++ b/src/kbucket/bucket.rs
@@ -217,17 +217,14 @@ impl<V> Bucket<V> {
 
 #[cfg(test)]
 mod tests {
-    use std::{thread, time::Duration};
+    use std::thread;
+    use std::time::Duration;
 
-    use crate::{
-        config::BucketConfig,
-        kbucket::{
-            bucket::NodeInsertError, key::BinaryKey, Bucket, Node,
-            NodeInsertOk, Tree,
-        },
-        peer::PeerNode,
-        K_BETA,
-    };
+    use super::*;
+    use crate::kbucket::Tree;
+    use crate::peer::PeerNode;
+    use crate::tests::Result;
+    use crate::K_BETA;
 
     impl<V> Bucket<V> {
         pub fn last_id(&self) -> Option<&BinaryKey> {
@@ -257,8 +254,8 @@ mod tests {
     }
 
     #[test]
-    fn test_lru_base_5secs() {
-        let root = PeerNode::generate("127.0.0.1:666");
+    fn test_lru_base_5secs() -> Result<()> {
+        let root = PeerNode::generate("127.0.0.1:666")?;
         let mut config = BucketConfig::default();
         config.node_evict_after = Duration::from_millis(1000);
         config.node_ttl = Duration::from_secs(5);
@@ -266,9 +263,9 @@ mod tests {
         let mut route_table = Tree::new(root, config);
 
         let bucket = route_table.bucket_for_test();
-        let node1 = PeerNode::generate("192.168.1.1:8080");
+        let node1 = PeerNode::generate("192.168.1.1:8080")?;
         let id_node1 = node1.id().as_binary().clone();
-        let node1_copy = PeerNode::generate("192.168.1.1:8080");
+        let node1_copy = PeerNode::generate("192.168.1.1:8080")?;
         match bucket.insert(node1).expect("This should return an ok()") {
             NodeInsertOk::Inserted { .. } => {}
             _ => assert!(false),
@@ -284,7 +281,7 @@ mod tests {
             _ => assert!(false),
         }
         assert_eq!(Some(&id_node1), bucket.last_id());
-        let node2 = PeerNode::generate("192.168.1.2:8080");
+        let node2 = PeerNode::generate("192.168.1.2:8080")?;
         let id_node2 = node2.id().as_binary().clone();
 
         match bucket.insert(node2).expect("This should return an ok()") {
@@ -297,7 +294,7 @@ mod tests {
         assert_eq!(Some(&id_node1), bucket.least_used_id());
 
         match bucket
-            .insert(PeerNode::generate("192.168.1.1:8080"))
+            .insert(PeerNode::generate("192.168.1.1:8080")?)
             .expect("This should return an ok()")
         {
             NodeInsertOk::Updated { .. } => {}
@@ -315,7 +312,7 @@ mod tests {
             match bucket
                 .insert(PeerNode::generate(
                     &format!("192.168.1.{}:8080", i)[..],
-                ))
+                )?)
                 .expect("This should return an ok()")
             {
                 NodeInsertOk::Inserted { .. } => {
@@ -325,7 +322,7 @@ mod tests {
             }
         }
         assert_eq!(bucket.pick::<K_BETA>().count(), K_BETA);
-        let pending = PeerNode::generate("192.168.1.21:8080");
+        let pending = PeerNode::generate("192.168.1.21:8080")?;
         let pending_id = pending.id().as_binary().clone();
         match bucket.insert(pending).expect_err("this should be error") {
             NodeInsertError::Full(pending) => {
@@ -341,7 +338,7 @@ mod tests {
                             &pending_id
                         );
                         thread::sleep(Duration::from_secs(1));
-                        let pending = PeerNode::generate("192.168.1.21:8080");
+                        let pending = PeerNode::generate("192.168.1.21:8080")?;
                         match bucket.insert(pending).expect("this should be ok")
                         {
                             NodeInsertOk::Inserted { inserted: _ } => {}
@@ -359,5 +356,6 @@ mod tests {
             }
             _ => assert!(false),
         }
+        Ok(())
     }
 }

--- a/src/kbucket/key.rs
+++ b/src/kbucket/key.rs
@@ -141,10 +141,17 @@ impl BinaryID {
 
 #[cfg(test)]
 mod tests {
-    use crate::{kbucket::BinaryID, peer::PeerNode};
+
+    use super::*;
+    use crate::kbucket::BucketHeight;
+    use crate::peer::PeerNode;
+    use crate::tests::Result;
 
     impl BinaryID {
-        fn calculate_distance_native(&self, other: &BinaryID) -> Option<usize> {
+        fn calculate_distance_native(
+            &self,
+            other: &BinaryID,
+        ) -> Option<BucketHeight> {
             let a = u128::from_le_bytes(*self.as_binary());
             let b = u128::from_le_bytes(*other.as_binary());
             let xor = a ^ b;
@@ -152,31 +159,33 @@ mod tests {
             if ret == 0 {
                 None
             } else {
-                Some(ret - 1)
+                Some((ret - 1) as u8)
             }
         }
     }
 
     #[test]
-    fn test_distance() {
-        let n1 = PeerNode::generate("192.168.0.1:666");
-        let n2 = PeerNode::generate("192.168.0.1:666");
+    fn test_distance() -> Result<()> {
+        let n1 = PeerNode::generate("192.168.0.1:666")?;
+        let n2 = PeerNode::generate("192.168.0.1:666")?;
         assert_eq!(n1.calculate_distance(&n2), None);
         assert_eq!(n1.id().calculate_distance_native(n2.id()), None);
         for i in 2..255 {
-            let n_in = PeerNode::generate(&format!("192.168.0.{}:666", i)[..]);
+            let n_in = PeerNode::generate(&format!("192.168.0.{}:666", i)[..])?;
             assert_eq!(
                 n1.calculate_distance(&n_in),
                 n1.id().calculate_distance_native(n_in.id())
             );
         }
+        Ok(())
     }
 
     #[test]
-    fn test_id_nonce() {
-        let root = PeerNode::generate("192.168.0.1:666");
+    fn test_id_nonce() -> Result<()> {
+        let root = PeerNode::generate("192.168.0.1:666")?;
         println!("Nonce is {:?}", root.id().nonce());
         assert!(root.id().verify_nonce());
+        Ok(())
     }
 
     #[test]

--- a/src/kbucket/node.rs
+++ b/src/kbucket/node.rs
@@ -7,6 +7,8 @@
 use std::time::{Duration, Instant};
 
 use super::key::BinaryID;
+use super::BucketHeight;
+
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Node<TValue> {
     id: BinaryID,
@@ -31,7 +33,10 @@ impl<TValue> Node<TValue> {
         }
     }
 
-    pub fn calculate_distance(&self, other: &Node<TValue>) -> Option<usize> {
+    pub fn calculate_distance(
+        &self,
+        other: &Node<TValue>,
+    ) -> Option<BucketHeight> {
         self.id.calculate_distance(other.id.as_binary())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -239,3 +239,9 @@ impl Peer {
             });
     }
 }
+
+#[cfg(test)]
+mod tests {
+
+    pub type Result<T> = core::result::Result<T, Box<dyn std::error::Error>>;
+}

--- a/src/mantainer.rs
+++ b/src/mantainer.rs
@@ -8,7 +8,7 @@ use std::net::{SocketAddr, ToSocketAddrs};
 use std::time::Duration;
 
 use tokio::sync::mpsc::Sender;
-use tracing::*;
+use tracing::{error, info};
 
 use crate::encoding::message::{Header, Message};
 use crate::kbucket::Tree;

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -81,16 +81,19 @@ impl PeerNode {
 
 #[cfg(test)]
 mod tests {
-    use crate::peer::PeerNode;
 
+    use crate::peer::PeerNode;
+    use crate::tests::Result;
     #[test]
-    fn test_verify_header() {
-        let wrong_header = PeerNode::generate("10.0.0.1:333").as_header();
+    fn test_verify_header() -> Result<()> {
+        let wrong_header = PeerNode::generate("10.0.0.1:333")?.as_header();
         let wrong_header_sameport =
-            PeerNode::generate("10.0.0.1:666").as_header();
+            PeerNode::generate("10.0.0.1:666")?.as_header();
         vec![
-            PeerNode::generate("192.168.1.1:666"),
-            PeerNode::generate("[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:666"),
+            PeerNode::generate("192.168.1.1:666")?,
+            PeerNode::generate(
+                "[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:666",
+            )?,
         ]
         .iter()
         .for_each(|n| {
@@ -100,5 +103,6 @@ mod tests {
             assert!(!PeerNode::verify_header(&wrong_header, ip));
             assert!(!PeerNode::verify_header(&wrong_header_sameport, ip));
         });
+        Ok(())
     }
 }

--- a/src/rwlock.rs
+++ b/src/rwlock.rs
@@ -7,8 +7,7 @@
 use std::{sync::Arc, time::Duration};
 
 use tokio::sync::RwLock as ExtRwLock;
-use tokio::sync::RwLockReadGuard;
-use tokio::sync::RwLockWriteGuard;
+use tokio::sync::{RwLockReadGuard, RwLockWriteGuard};
 use tokio::time::timeout;
 use tracing::warn;
 

--- a/src/transport/encoding.rs
+++ b/src/transport/encoding.rs
@@ -7,14 +7,16 @@
 mod plain_encoder;
 mod raptorq;
 
+use std::io;
+
 pub(crate) use self::raptorq::RaptorQDecoder as TransportDecoder;
 pub(crate) use self::raptorq::RaptorQEncoder as TransportEncoder;
+use crate::encoding::message::Message;
 
 pub type TransportEncoderConfig =
     <self::TransportEncoder as Configurable>::TConf;
 pub type TransportDecoderConfig =
     <self::TransportDecoder as Configurable>::TConf;
-use crate::encoding::message::Message;
 
 pub trait Configurable {
     type TConf;
@@ -23,9 +25,9 @@ pub trait Configurable {
 }
 
 pub(crate) trait Encoder: Configurable {
-    fn encode(&self, msg: Message) -> Vec<Message>;
+    fn encode(&self, msg: Message) -> io::Result<Vec<Message>>;
 }
 
 pub(crate) trait Decoder: Configurable {
-    fn decode(&mut self, chunk: Message) -> Option<Message>;
+    fn decode(&mut self, chunk: Message) -> io::Result<Option<Message>>;
 }

--- a/src/transport/encoding/plain_encoder.rs
+++ b/src/transport/encoding/plain_encoder.rs
@@ -5,10 +5,10 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use std::collections::HashMap;
-
-use crate::encoding::message::Message;
+use std::io;
 
 use super::{Configurable, Decoder, Encoder};
+use crate::encoding::message::Message;
 
 pub(crate) struct PlainEncoder {}
 
@@ -23,17 +23,17 @@ impl Configurable for PlainEncoder {
 }
 
 impl Encoder for PlainEncoder {
-    fn encode<'msg>(&self, msg: Message) -> Vec<Message> {
-        vec![msg]
+    fn encode<'msg>(&self, msg: Message) -> io::Result<Vec<Message>> {
+        Ok(vec![msg])
     }
 }
 
 impl Decoder for PlainEncoder {
-    fn decode(&mut self, chunk: Message) -> Option<Message> {
+    fn decode(&mut self, chunk: Message) -> io::Result<Option<Message>> {
         if let Message::Broadcast(header, payload) = chunk {
-            Some(Message::Broadcast(header, payload))
+            Ok(Some(Message::Broadcast(header, payload)))
         } else {
-            Some(chunk)
+            Ok(Some(chunk))
         }
     }
 }

--- a/src/transport/encoding/raptorq/decoder.rs
+++ b/src/transport/encoding/raptorq/decoder.rs
@@ -162,13 +162,11 @@ impl Decoder for RaptorQDecoder {
 mod tests {
     use std::{thread, time::Duration};
 
-    use super::RaptorQDecoder;
+    use super::*;
+    use crate::peer::PeerNode;
+    use crate::tests::Result;
     use crate::transport::encoding::raptorq::RaptorQEncoder;
-    use crate::{
-        encoding::{message::Message, payload::BroadcastPayload},
-        peer::PeerNode,
-        transport::encoding::{Configurable, Decoder, Encoder},
-    };
+    use crate::transport::encoding::Encoder;
 
     impl RaptorQDecoder {
         fn cache_size(&self) -> usize {
@@ -177,8 +175,8 @@ mod tests {
     }
 
     #[test]
-    fn test_expiring_cache() {
-        let root = PeerNode::generate("192.168.0.1:666");
+    fn test_expiring_cache() -> Result<()> {
+        let root = PeerNode::generate("192.168.0.1:666")?;
         let enc =
             RaptorQEncoder::configure(&RaptorQEncoder::default_configuration());
         let mut conf = RaptorQDecoder::default_configuration();
@@ -194,8 +192,8 @@ mod tests {
                 height: 0,
                 gossip_frame: vec![0],
             },
-        )) {
-            dec.decode(n);
+        ))? {
+            dec.decode(n)?;
         }
         assert_eq!(dec.cache_size(), 1);
 
@@ -214,8 +212,8 @@ mod tests {
                     height: 0,
                     gossip_frame: vec![i],
                 },
-            )) {
-                dec.decode(n);
+            ))? {
+                dec.decode(n)?;
             }
         }
         assert_eq!(dec.cache_size(), 3);
@@ -230,9 +228,10 @@ mod tests {
                 height: 0,
                 gossip_frame: vec![0],
             },
-        )) {
-            dec.decode(n);
+        ))? {
+            dec.decode(n)?;
         }
         assert_eq!(dec.cache_size(), 1);
+        Ok(())
     }
 }

--- a/src/transport/sockets.rs
+++ b/src/transport/sockets.rs
@@ -4,16 +4,21 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use std::{io, time::Duration};
+use std::io;
+use std::net::SocketAddr;
+use std::time::Duration;
 
-use super::*;
+use tokio::net::UdpSocket;
 use tokio::runtime::Handle;
 use tokio::task::block_in_place;
-use tokio::time::Interval;
+use tokio::time::{self, Interval};
 use tracing::{info, warn};
 
+use super::encoding::Configurable;
 use crate::config::NetworkConfig;
+
 const MIN_RETRY_COUNT: u8 = 1;
+
 pub(super) struct MultipleOutSocket {
     ipv4: UdpSocket,
     ipv6: UdpSocket,


### PR DESCRIPTION
This is a larger refactor that aims to make the library more stable by removing unwrap and expect.

* Change `Peer::new` to return Result
* Change `blake2` from `0.9` to `0.10`

Resolves #115

