### PR TITLE
0.5.0-rc.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
 name = "kadcast"
 authors = ["herr-seppia <seppia@dusk.network>"]
-version = "0.5.0-rc.0"
+version = "0.5.0-rc.1"
 edition = "2018"
 description = "Implementation of the Kadcast Network Protocol."
 categories = ["network-programming"]
 keywords = ["p2p", "network", "kad", "peer-to-peer", "kadcast"]
 license = "MPL-2.0"
 repository = "https://github.com/dusk-network/kadcast"
+publish = false
 
 exclude = [".git*", "ARCHITECTURE.md", "architecture.jpg"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ categories = ["network-programming"]
 keywords = ["p2p", "network", "kad", "peer-to-peer", "kadcast"]
 license = "MPL-2.0"
 repository = "https://github.com/dusk-network/kadcast"
-publish = false
 
 exclude = [".git*", "ARCHITECTURE.md", "architecture.jpg"]
 


### PR DESCRIPTION
* Enable crates.io publish for `0.5.0-rc.0`
* Bump version to `0.5.0-rc.1`