### PR TITLE
Release `0.6.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2023-11-01
+
 ### Added
 
-- Add new facade function `new` to creating `RwLock` based on feature flag. [#94]
+- Add new facade function `new` to creating `RwLock` based on feature flag [#94]
 - Add `NetworkId` in configuration [#123]
 
 ### Changed
@@ -127,7 +129,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- Releases -->
 
-[Unreleased]: https://github.com/dusk-network/kadcast/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/dusk-network/kadcast/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/dusk-network/kadcast/compare/v0.5.0...v0.6.0
 [0.5.1]: https://github.com/dusk-network/kadcast/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/dusk-network/kadcast/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/dusk-network/kadcast/compare/v0.3.0...v0.4.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kadcast"
 authors = ["herr-seppia <seppia@dusk.network>"]
-version = "0.6.0-rc.0"
+version = "0.6.0"
 edition = "2018"
 description = "Implementation of the Kadcast Network Protocol."
 categories = ["network-programming"]


### PR DESCRIPTION
## [0.6.0] - 2023-11-01

### Added

- Add new facade function `new` to creating `RwLock` based on feature flag [#94]
- Add `NetworkId` in configuration [#123]

### Changed

- Change `RwLock` API to support diagnostics feature flag [#94]
- Change network wire encoding to support `NetworkId` [#123]

[0.6.0]: https://github.com/dusk-network/kadcast/compare/v0.5.0...v0.6.0