### PR TITLE
Release `0.6.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2024-04-10
+
 ### Added
 
 - Add `BucketConfig::min_peers` in configuration [#135]
@@ -142,7 +144,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- Releases -->
 
-[Unreleased]: https://github.com/dusk-network/kadcast/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/dusk-network/kadcast/compare/v0.6.1...HEAD
+[0.6.1]: https://github.com/dusk-network/kadcast/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/dusk-network/kadcast/compare/v0.5.0...v0.6.0
 [0.5.1]: https://github.com/dusk-network/kadcast/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/dusk-network/kadcast/compare/v0.4.0...v0.4.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kadcast"
 authors = ["herr-seppia <seppia@dusk.network>"]
-version = "0.6.0"
+version = "0.6.1"
 edition = "2018"
 description = "Implementation of the Kadcast Network Protocol."
 categories = ["network-programming"]


### PR DESCRIPTION
## [0.6.1] - 2024-04-10

### Added

- Add `BucketConfig::min_peers` in configuration [#135]

### Changed

- Change 'need_bootstrappers' to have dinamically threshold [#135]
- Change `BinaryID::from_nonce` to return result [#136]
- Change maintainer to ping nodes while removal [#138]

[0.6.1]: https://github.com/dusk-network/kadcast/compare/v0.6.0...v0.6.1