### PR TITLE
Change raptorq decoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `max_udp_len` configuration parameter
+- Add checks for MTU to be in range between 1296 and 8192
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `max_udp_len` configuration parameter
-- Add checks for MTU to be in range between 1296 and 8192
+- Add range checks to MTU (between 1296 and 8192)
 
 ### Fixed
 
@@ -21,7 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Change the EncodedChunk UUID generation
 - Change `raptorq` dependency from `1.6` to `2.0`
-- Change default MTU to `8192`
 
 ## [0.6.1] - 2024-04-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix raptorQ cache default config
+
+### Changed
+
+- Change the EncodedChunk UUID generation
+- Change `raptorq` dependency from `1.6` to `2.0`
+
 ## [0.6.1] - 2024-04-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `max_udp_len` configuration parameter
+
 ### Fixed
 
 - Fix raptorQ cache default config
+- Fix ObjectTransmissionInformation deserialization
 
 ### Changed
 
 - Change the EncodedChunk UUID generation
 - Change `raptorq` dependency from `1.6` to `2.0`
+- Change default MTU to `8192`
 
 ## [0.6.1] - 2024-04-10
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kadcast"
 authors = ["herr-seppia <seppia@dusk.network>"]
-version = "0.7.0-rc.0"
+version = "0.7.0-rc.1"
 edition = "2018"
 description = "Implementation of the Kadcast Network Protocol."
 categories = ["network-programming"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kadcast"
 authors = ["herr-seppia <seppia@dusk.network>"]
-version = "0.7.0-rc.2"
+version = "0.7.0-rc.3"
 edition = "2018"
 description = "Implementation of the Kadcast Network Protocol."
 categories = ["network-programming"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kadcast"
 authors = ["herr-seppia <seppia@dusk.network>"]
-version = "0.7.0-rc.1"
+version = "0.7.0-rc.2"
 edition = "2018"
 description = "Implementation of the Kadcast Network Protocol."
 categories = ["network-programming"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ arrayvec = "0.7"
 blake2 = "0.10"
 rand = "0.8"
 tokio = { version = "1", features = ["rt", "net", "sync", "time", "io-std", "rt-multi-thread", "macros"] }
-raptorq = { version = "1.6", optional = true }
+raptorq = { version = "2.0", optional = true }
 tracing = "0.1"
 itertools = "0.10"
 konst = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kadcast"
 authors = ["herr-seppia <seppia@dusk.network>"]
-version = "0.6.1"
+version = "0.7.0-rc.0"
 edition = "2018"
 description = "Implementation of the Kadcast Network Protocol."
 categories = ["network-programming"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kadcast"
 authors = ["herr-seppia <seppia@dusk.network>"]
-version = "0.7.0-rc.3"
+version = "0.7.0-rc.4"
 edition = "2018"
 description = "Implementation of the Kadcast Network Protocol."
 categories = ["network-programming"]

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -100,9 +100,9 @@ mod tests {
         let mut bytes = vec![];
         c.seek(std::io::SeekFrom::Start(0))?;
         c.read_to_end(&mut bytes)?;
-        c.seek(std::io::SeekFrom::Start(0))?;
         println!("bytes: {:?}", bytes);
         println!("byhex: {:02X?}", bytes);
+        let c = Cursor::new(bytes);
         let mut reader = BufReader::new(c);
         let deser = Message::unmarshal_binary(&mut reader)?;
 

--- a/src/handling.rs
+++ b/src/handling.rs
@@ -14,7 +14,7 @@ use crate::encoding::message::{
     BroadcastPayload, Header, Message, NodePayload,
 };
 use crate::kbucket::{BinaryKey, NodeInsertError, Tree};
-use crate::peer::{PeerInfo, PeerNode};
+use crate::peer::{self, PeerInfo, PeerNode};
 use crate::transport::{MessageBeanIn, MessageBeanOut};
 use crate::{RwLock, K_K};
 
@@ -93,6 +93,12 @@ impl MessageHandler {
                 debug!("Handler received message");
                 trace!("Handler received message {:?}", message);
                 remote_peer_addr.set_port(message.header().sender_port);
+
+                let header = message.header();
+                let src = remote_peer_addr.ip();
+                if !PeerNode::verify_header(header, &src) {
+                    error!("Invalid Id {header:?} - from {src}");
+                }
 
                 let remote_peer = PeerNode::from_socket(
                     remote_peer_addr,

--- a/src/handling.rs
+++ b/src/handling.rs
@@ -14,7 +14,7 @@ use crate::encoding::message::{
     BroadcastPayload, Header, Message, NodePayload,
 };
 use crate::kbucket::{BinaryKey, NodeInsertError, Tree};
-use crate::peer::{self, PeerInfo, PeerNode};
+use crate::peer::{PeerInfo, PeerNode};
 use crate::transport::{MessageBeanIn, MessageBeanOut};
 use crate::{RwLock, K_K};
 

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -17,7 +17,6 @@ use tracing::{debug, error, info, warn};
 use crate::config::Config;
 use crate::encoding::message::Message;
 use crate::encoding::Marshallable;
-use crate::peer::PeerNode;
 use crate::rwlock::RwLock;
 use crate::transport::encoding::{
     Configurable, Decoder, Encoder, TransportDecoder, TransportEncoder,

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -100,8 +100,6 @@ impl WireNetwork {
 
             dec_chan_tx
                 .try_send((bytes[0..len].to_vec(), remote_address))
-                // .send((bytes[0..len].to_vec(), remote_address))
-                // .await
                 .unwrap_or_else(|e| {
                     error!("Unable to send to dec_chan_tx channel {e}")
                 });

--- a/src/transport/encoding/raptorq.rs
+++ b/src/transport/encoding/raptorq.rs
@@ -67,13 +67,13 @@ impl<'a> ChunkedPayload<'a> {
 
     fn transmission_info(
         &self,
-        max_udp_len: usize,
+        max_udp_len: u64,
     ) -> Result<SafeObjectTransmissionInformation, TransmissionInformationError>
     {
         let slice =
             &self.0.gossip_frame[UID_SIZE..(UID_SIZE + TRANSMISSION_INFO_SIZE)];
         let info = SafeObjectTransmissionInformation::try_from(slice)?;
-        match info.max_blocks < max_udp_len {
+        match info.inner.transfer_length() < max_udp_len {
             true => Ok(info),
             false => Err(TransmissionInformationError::TransferLengthExceeded),
         }

--- a/src/transport/encoding/raptorq/decoder.rs
+++ b/src/transport/encoding/raptorq/decoder.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::convert::TryInto;
 use std::io;
 use std::time::{Duration, Instant};
@@ -25,7 +25,7 @@ const DEFAULT_CACHE_PRUNE_EVERY: Duration = Duration::from_secs(30);
 const DEFAULT_MAX_UDP_LEN: u64 = 10 * 1_024 * 1_024;
 
 pub struct RaptorQDecoder {
-    cache: HashMap<[u8; UID_SIZE + TRANSMISSION_INFO_SIZE], CacheStatus>,
+    cache: BTreeMap<[u8; UID_SIZE + TRANSMISSION_INFO_SIZE], CacheStatus>,
     last_pruned: Instant,
     conf: RaptorQDecoderConf,
 }
@@ -57,7 +57,7 @@ impl Configurable for RaptorQDecoder {
     fn configure(conf: &Self::TConf) -> Self {
         Self {
             conf: *conf,
-            cache: HashMap::new(),
+            cache: BTreeMap::new(),
             last_pruned: Instant::now(),
         }
     }
@@ -88,12 +88,12 @@ impl Decoder for RaptorQDecoder {
             // Perform a `match` on the cache entry against the uid.
             let status = match self.cache.entry(uid) {
                 // Cache status exists: return it
-                std::collections::hash_map::Entry::Occupied(o) => o.into_mut(),
+                std::collections::btree_map::Entry::Occupied(o) => o.into_mut(),
 
                 // Cache status not found: creates a new entry with
                 // CacheStatus::Receiving status and binds a new Decoder with
                 // the received transmission information
-                std::collections::hash_map::Entry::Vacant(v) => {
+                std::collections::btree_map::Entry::Vacant(v) => {
                     let info = chunked.transmission_info(self.conf.max_udp_len);
                     match info {
                         Ok(safe_info) => v.insert(CacheStatus::Receiving(

--- a/src/transport/encoding/raptorq/decoder.rs
+++ b/src/transport/encoding/raptorq/decoder.rs
@@ -22,7 +22,7 @@ use crate::transport::Decoder;
 const DEFAULT_CACHE_TTL: Duration = Duration::from_secs(60);
 const DEFAULT_CACHE_PRUNE_EVERY: Duration = Duration::from_secs(30);
 
-const DEFAULT_MAX_UDP_LEN: usize = 10_000_000;
+const DEFAULT_MAX_UDP_LEN: u64 = 10 * 1_024 * 1_024;
 
 pub struct RaptorQDecoder {
     cache: HashMap<[u8; UID_SIZE + TRANSMISSION_INFO_SIZE], CacheStatus>,
@@ -38,10 +38,10 @@ pub struct RaptorQDecoderConf {
     pub cache_prune_every: Duration,
 
     #[serde(default = "default_max_udp_len")]
-    pub max_udp_len: usize,
+    pub max_udp_len: u64,
 }
 
-const fn default_max_udp_len() -> usize {
+const fn default_max_udp_len() -> u64 {
     DEFAULT_MAX_UDP_LEN
 }
 

--- a/src/transport/encoding/raptorq/decoder.rs
+++ b/src/transport/encoding/raptorq/decoder.rs
@@ -19,8 +19,8 @@ use crate::encoding::payload::BroadcastPayload;
 use crate::transport::encoding::Configurable;
 use crate::transport::Decoder;
 
-const DEFAULT_CACHE_TTL_SECS: u64 = 60;
-const DEFAULT_CACHE_PRUNE_EVERY_SECS: u64 = 60 * 5;
+const DEFAULT_CACHE_TTL: Duration = Duration::from_secs(60);
+const DEFAULT_CACHE_PRUNE_EVERY: Duration = Duration::from_secs(30);
 
 pub struct RaptorQDecoder {
     cache: HashMap<[u8; 32], CacheStatus>,
@@ -40,10 +40,8 @@ impl Configurable for RaptorQDecoder {
     type TConf = RaptorQDecoderConf;
     fn default_configuration() -> Self::TConf {
         RaptorQDecoderConf {
-            cache_prune_every: Duration::from_secs(
-                DEFAULT_CACHE_PRUNE_EVERY_SECS,
-            ),
-            cache_ttl: Duration::from_secs(DEFAULT_CACHE_TTL_SECS),
+            cache_prune_every: DEFAULT_CACHE_PRUNE_EVERY,
+            cache_ttl: DEFAULT_CACHE_TTL,
         }
     }
     fn configure(conf: &Self::TConf) -> Self {

--- a/src/transport/encoding/raptorq/encoder.rs
+++ b/src/transport/encoding/raptorq/encoder.rs
@@ -12,7 +12,7 @@ use crate::transport::encoding::Configurable;
 use crate::transport::Encoder;
 
 const DEFAULT_MIN_REPAIR_PACKETS_PER_BLOCK: u32 = 5;
-const DEFAULT_MTU: u16 = 1300;
+const DEFAULT_MTU: u16 = 8192;
 const DEFAULT_FEQ_REDUNDANCY: f32 = 0.15;
 
 use raptorq::Encoder as ExtEncoder;

--- a/src/transport/encoding/raptorq/encoder.rs
+++ b/src/transport/encoding/raptorq/encoder.rs
@@ -14,8 +14,8 @@ use crate::transport::Encoder;
 const DEFAULT_MIN_REPAIR_PACKETS_PER_BLOCK: u32 = 5;
 const DEFAULT_MTU: u16 = 1300;
 
-pub const MAX_MTU: u16 = 8192;
-pub const MIN_MTU: u16 = 1296;
+pub(crate) const MAX_MTU: u16 = 8192;
+pub(crate) const MIN_MTU: u16 = 1296;
 
 const DEFAULT_FEQ_REDUNDANCY: f32 = 0.15;
 

--- a/src/transport/encoding/raptorq/encoder.rs
+++ b/src/transport/encoding/raptorq/encoder.rs
@@ -12,7 +12,7 @@ use crate::transport::encoding::Configurable;
 use crate::transport::Encoder;
 
 const DEFAULT_MIN_REPAIR_PACKETS_PER_BLOCK: u32 = 5;
-const DEFAULT_MTU: u16 = 8192;
+const DEFAULT_MTU: u16 = 1300;
 
 pub const MAX_MTU: u16 = 8192;
 pub const MIN_MTU: u16 = 1296;

--- a/src/transport/encoding/raptorq/encoder.rs
+++ b/src/transport/encoding/raptorq/encoder.rs
@@ -13,6 +13,10 @@ use crate::transport::Encoder;
 
 const DEFAULT_MIN_REPAIR_PACKETS_PER_BLOCK: u32 = 5;
 const DEFAULT_MTU: u16 = 8192;
+
+pub const MAX_MTU: u16 = 8192;
+pub const MIN_MTU: u16 = 1296;
+
 const DEFAULT_FEQ_REDUNDANCY: f32 = 0.15;
 
 use raptorq::Encoder as ExtEncoder;
@@ -46,7 +50,17 @@ impl Configurable for RaptorQEncoder {
         RaptorQEncoderConf::default()
     }
     fn configure(conf: &Self::TConf) -> Self {
-        Self { conf: *conf }
+        let mut conf = *conf;
+        let mtu = conf.mtu;
+        if mtu > MAX_MTU {
+            tracing::warn!("MTU={mtu} too high, changing to {DEFAULT_MTU}");
+            conf.mtu = DEFAULT_MTU;
+        }
+        if mtu < MIN_MTU {
+            tracing::warn!("MTU={mtu} too low, changing to {DEFAULT_MTU}");
+            conf.mtu = DEFAULT_MTU;
+        }
+        Self { conf }
     }
 }
 

--- a/src/transport/encoding/raptorq/safe.rs
+++ b/src/transport/encoding/raptorq/safe.rs
@@ -52,6 +52,7 @@ fn int_div_ceil(num: u64, denom: u64) -> u32 {
 // K'_max as defined in section 5.1.2
 const MAX_SOURCE_SYMBOLS_PER_BLOCK: u32 = 56403;
 
+#[derive(Debug, Clone)]
 pub(crate) struct SafeObjectTransmissionInformation {
     pub inner: ObjectTransmissionInformation,
     pub max_blocks: usize,

--- a/src/transport/encoding/raptorq/safe.rs
+++ b/src/transport/encoding/raptorq/safe.rs
@@ -1,0 +1,97 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+/*
+ * The original implementation of this file can be found at:
+ * https://github.com/cberner/raptorq
+ *
+ * The original work is licensed under the Apache License, Version 2.0.
+ *
+ * Modifications made:
+ * - Add implementation for a safe ObjectTransmissionInformation
+ *   deserialization that checks parameter in order to prevent panic at
+ *   runtime
+ *
+ * The following is a notice for the original file:
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::convert::{TryFrom, TryInto};
+
+use raptorq::ObjectTransmissionInformation;
+
+use super::TRANSMISSION_INFO_SIZE;
+
+// This should eventually become <https://doc.rust-lang.org/std/primitive.u64.html#method.div_ceil>
+// when it gets stabilized, and this function should be removed.
+// (1) the result is known to not overflow u32 from elsewhere;
+// (2) `denom` is known to not be `0` from elsewhere.
+// TODO this is definitely not always the case! Let's do something about it.
+fn int_div_ceil(num: u64, denom: u64) -> u32 {
+    if num % denom == 0 {
+        (num / denom) as u32
+    } else {
+        (num / denom + 1) as u32
+    }
+}
+
+// K'_max as defined in section 5.1.2
+const MAX_SOURCE_SYMBOLS_PER_BLOCK: u32 = 56403;
+
+pub(crate) struct SafeObjectTransmissionInformation {
+    pub inner: ObjectTransmissionInformation,
+    pub max_blocks: usize,
+}
+
+#[derive(Debug, Clone)]
+pub enum TransmissionInformationError {
+    InvalidSize,
+    SourceBlocksEmpy,
+    TransferLengthExceeded,
+    TooManySourceSymbols,
+}
+
+impl TryFrom<&[u8]> for SafeObjectTransmissionInformation {
+    type Error = TransmissionInformationError;
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        let value: &[u8; TRANSMISSION_INFO_SIZE] = value
+            .try_into()
+            .map_err(|_| TransmissionInformationError::InvalidSize)?;
+        let config = ObjectTransmissionInformation::deserialize(value);
+
+        if config.source_blocks() == 0 {
+            return Err(TransmissionInformationError::SourceBlocksEmpy);
+        }
+
+        let kt =
+            int_div_ceil(config.transfer_length(), config.symbol_size() as u64);
+
+        let (kl, _, zl, zs) = raptorq::partition(kt, config.source_blocks());
+
+        let block_length = u64::from(kl) * u64::from(config.symbol_size());
+        let source_block_symbols =
+            int_div_ceil(block_length, config.symbol_size() as u64);
+
+        match source_block_symbols <= MAX_SOURCE_SYMBOLS_PER_BLOCK {
+            true => Ok(SafeObjectTransmissionInformation {
+                inner: config,
+                max_blocks: (zl + zs) as usize,
+            }),
+            false => Err(TransmissionInformationError::TooManySourceSymbols),
+        }
+    }
+}


### PR DESCRIPTION
### Added

- Add `max_udp_len` configuration parameter
- Add range checks to MTU (between 1296 and 8192)

### Fixed

- Fix raptorQ cache default config
- Fix ObjectTransmissionInformation deserialization

### Changed

- Change the EncodedChunk UUID generation
- Change `raptorq` dependency from `1.6` to `2.0`