### PR TITLE
Prevent duplicate message processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix raptorQ cache default config
 - Fix ObjectTransmissionInformation deserialization
+- Fix duplicate processing for messages with different RaptorQ configurations
 
 ### Changed
 

--- a/src/transport/encoding/raptorq/safe.rs
+++ b/src/transport/encoding/raptorq/safe.rs
@@ -30,7 +30,7 @@
  * limitations under the License.
  */
 
-use std::convert::{TryFrom, TryInto};
+use std::convert::TryFrom;
 
 use raptorq::ObjectTransmissionInformation;
 
@@ -60,7 +60,6 @@ pub(crate) struct SafeObjectTransmissionInformation {
 
 #[derive(Debug, Clone)]
 pub enum TransmissionInformationError {
-    InvalidSize,
     SourceBlocksZero,
     SymbolSizeZero,
     SymbolSizeGreaterThanMTU,
@@ -70,12 +69,13 @@ pub enum TransmissionInformationError {
     TooManySourceSymbols,
 }
 
-impl TryFrom<&[u8]> for SafeObjectTransmissionInformation {
+impl TryFrom<&[u8; TRANSMISSION_INFO_SIZE]>
+    for SafeObjectTransmissionInformation
+{
     type Error = TransmissionInformationError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        let value: &[u8; TRANSMISSION_INFO_SIZE] = value
-            .try_into()
-            .map_err(|_| TransmissionInformationError::InvalidSize)?;
+    fn try_from(
+        value: &[u8; TRANSMISSION_INFO_SIZE],
+    ) -> Result<Self, Self::Error> {
         let config = ObjectTransmissionInformation::deserialize(value);
 
         if config.source_blocks() == 0 {


### PR DESCRIPTION
Handle cache to ensure that the same message is not processed twice if sent with different RaptorQ configurations

Change the processing dupemap from`Map<rayid+encodeinfo, decoder>` to `Map<rayid, Map<encodeinfo, decoder>>`