### PR TITLE
Release 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2024-10-21
+
 ### Added
 
 - Add `Peer::to_route_table` API
@@ -169,7 +171,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- Releases -->
 
-[Unreleased]: https://github.com/dusk-network/kadcast/compare/v0.6.1...HEAD
+[Unreleased]: https://github.com/dusk-network/kadcast/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/dusk-network/kadcast/compare/v0.6.1...v0.7.0
 [0.6.1]: https://github.com/dusk-network/kadcast/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/dusk-network/kadcast/compare/v0.5.0...v0.6.0
 [0.5.1]: https://github.com/dusk-network/kadcast/compare/v0.4.1...v0.5.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kadcast"
 authors = ["herr-seppia <seppia@dusk.network>"]
-version = "0.7.0-rc.11"
+version = "0.7.0"
 edition = "2018"
 description = "Implementation of the Kadcast Network Protocol."
 categories = ["network-programming"]


### PR DESCRIPTION
## [0.7.0] - 2024-10-21

### Added

- Add `Peer::to_route_table` API
- Add `Peer:send_to_peers` API
- Add `max_udp_len` configuration parameter
- Add range checks to MTU (between 1296 and 8192)
- Add network version to handshake messages
- Add Ray-ID to MessageInfo for message tracking
- Add warning when discarding incomplete messages
- Add tracing when broadcasting to an eclipsed network	

### Fixed

- Fix raptorQ cache default config
- Fix ObjectTransmissionInformation deserialization
- Fix duplicate processing for messages with different RaptorQ configurations
- Fix idle nodes removal on maintainance
- Fix `find_new_nodes` to query the proper buckets	

### Changed

- Change the EncodedChunk UUID generation (aka RaptorqHeader)
- Change `raptorq` dependency from `1.6` to `2.0`
- Change UDP sender to raise error if timeout`



[0.7.0]: https://github.com/dusk-network/kadcast/compare/v0.6.1...v0.7.0