### PR TITLE
Force v-prefixed release tags

### DIFF
--- a/release.toml
+++ b/release.toml
@@ -1,6 +1,6 @@
 push = true
 tag = true
-tag-name = "{{prefix}}{{version}}"
+tag-name = "v{{version}}"
 publish = false
 pre-release-commit-message = "{{crate_name}}: release `{{version}}`"
 tag-message = "{{crate_name}}: tag {{version}}"


### PR DESCRIPTION
## Summary
- force release tag format to `v{{version}}` in `release.toml`
- avoid creating non-prefixed tags like `0.8.0-rc.1`

## Why
The repository tag history follows the `v<semver>` convention, so the release configuration should enforce it explicitly.