### PR TITLE
Release kadcast v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-06-12
+
 ### Fixed
 
 - Reject messages from invalid peers (P1.10-3)
@@ -14,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Move to stable MSRV 1.85
+- Move to stable MSRV 1.89
 - Move to rust edition 2024
 - Limit the number of peers accepted in a single Nodes message (P1.10-4)
 - Increase the POW produced during ID generation (P1.10-2)
@@ -189,7 +191,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- Releases -->
 
-[Unreleased]: https://github.com/dusk-network/kadcast/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/dusk-network/kadcast/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/dusk-network/kadcast/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/dusk-network/kadcast/compare/v0.6.1...v0.7.0
 [0.6.1]: https://github.com/dusk-network/kadcast/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/dusk-network/kadcast/compare/v0.5.0...v0.6.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kadcast"
 authors = ["herr-seppia <seppia@dusk.network>"]
-version = "0.8.0-rc.2"
+version = "0.8.0"
 description = "Implementation of the Kadcast Network Protocol."
 categories = ["network-programming"]
 keywords = ["p2p", "network", "kad", "peer-to-peer", "kadcast"]
@@ -9,7 +9,7 @@ license = "MPL-2.0"
 repository = "https://github.com/dusk-network/kadcast"
 publish = true
 
-rust-version = "1.85"
+rust-version = "1.89"
 edition = "2024"
 
 exclude = [".git*", "ARCHITECTURE.md", "architecture.jpg"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "stable"
+channel = "1.89"
 components = ["rustfmt", "clippy"]

--- a/src/kbucket.rs
+++ b/src/kbucket.rs
@@ -85,8 +85,8 @@ impl<V> Tree<V> {
         other: &BinaryKey,
     ) -> impl Iterator<Item = &Node<V>> {
         self.buckets
-            .iter()
-            .flat_map(|(_, b)| b.peers())
+            .values()
+            .flat_map(|b| b.peers())
             .filter(|p| p.id().as_binary() != other)
             .sorted_by(|a, b| {
                 let distance_a = a.id().calculate_distance(other);
@@ -141,7 +141,7 @@ impl<V> Tree<V> {
     }
 
     pub(crate) fn idle_nodes(&self) -> impl Iterator<Item = &Node<V>> {
-        self.buckets.iter().flat_map(|(_, b)| b.idle_nodes())
+        self.buckets.values().flat_map(|b| b.idle_nodes())
     }
 
     pub(crate) fn remove_idle_nodes(&mut self) {
@@ -152,8 +152,8 @@ impl<V> Tree<V> {
 
     pub(crate) fn alive_nodes(&self) -> impl Iterator<Item = &Node<V>> {
         self.buckets
-            .iter()
-            .flat_map(|(_, bucket)| bucket.alive_nodes())
+            .values()
+            .flat_map(|bucket| bucket.alive_nodes())
     }
 
     pub(crate) fn is_bucket_full(&self, height: BucketHeight) -> bool {

--- a/src/kbucket/bucket.rs
+++ b/src/kbucket/bucket.rs
@@ -108,14 +108,14 @@ impl<V> Bucket<V> {
         if self.nodes.is_full() {
             return;
         };
-        if let Some(pending) = self.pending_node.take() {
-            if pending.is_alive(self.bucket_config.node_ttl) {
-                // FIXME: Consider using `try_push` instead of `push`.
-                // FIXME2: This may break the LRU policy, as other records may
-                // have been updated in the meantime. However, it is mitigated
-                // by the `is_alive` check.
-                self.nodes.push(pending);
-            }
+        if let Some(pending) = self.pending_node.take()
+            && pending.is_alive(self.bucket_config.node_ttl)
+        {
+            // FIXME: Consider using `try_push` instead of `push`.
+            // FIXME2: This may break the LRU policy, as other records may
+            // have been updated in the meantime. However, it is mitigated
+            // by the `is_alive` check.
+            self.nodes.push(pending);
         }
     }
 
@@ -287,10 +287,10 @@ impl<V> Bucket<V> {
             self.nodes.iter().position(|s| s.id().as_binary() == id)?;
 
         self.nodes.pop_at(node_idx).inspect(|_| {
-            if let Some(pending) = self.pending_node.take() {
-                if pending.is_alive(self.bucket_config.node_ttl) {
-                    self.nodes.push(pending);
-                }
+            if let Some(pending) = self.pending_node.take()
+                && pending.is_alive(self.bucket_config.node_ttl)
+            {
+                self.nodes.push(pending);
             }
         })
     }

--- a/src/maintainer.rs
+++ b/src/maintainer.rs
@@ -157,7 +157,7 @@ impl TableMaintainer {
             .alive_nodes()
             .map(|n| n.as_peer_info().to_socket_address())
             .take(K_ALPHA)
-            .chain(self.bootstrapping_nodes_addr().into_iter())
+            .chain(self.bootstrapping_nodes_addr())
             .collect::<Vec<_>>();
 
         for bucket_h in buckets_to_refresh {


### PR DESCRIPTION
## Summary

- promote kadcast from 0.8.0-rc.2 to 0.8.0
- move the current unreleased changelog entries into the 0.8.0 release section
- update changelog comparison links for the v0.8.0 tag

## Validation

- cargo check --all-features
- make test
- cargo package --allow-dirty --no-verify

## Release notes

After this PR merges, tag the merge commit as v0.8.0 and publish the kadcast 0.8.0 crate.